### PR TITLE
Fix IE 11 compatibility

### DIFF
--- a/view/base/web/js/model/shipping-settings.js
+++ b/view/base/web/js/model/shipping-settings.js
@@ -1,7 +1,8 @@
 define([
     'ko',
-    'Dhl_Ui/js/action/util/hash'
-], function (ko, hash) {
+    'Dhl_Ui/js/action/util/hash',
+    'underscore'
+], function (ko, hash, _) {
     'use strict';
 
     /**
@@ -131,7 +132,7 @@ define([
                 return false;
             }
 
-            carrierData = settings().carriers.find(function (carrier) {
+            carrierData = _.find(settings().carriers, function (carrier) {
                 return carrier.code === carrierName;
             });
 

--- a/view/frontend/web/js/model/checkout/footnotes.js
+++ b/view/frontend/web/js/model/checkout/footnotes.js
@@ -55,9 +55,9 @@ define([
         getById: function (footnoteId) {
             var match = false;
             if (typeof getCarrierData() !== 'undefined' && typeof getCarrierData().metadata !== 'undefined') {
-                 match = getCarrierData().metadata.footnotes.find(function (footnote) {
+                match = _.find(getCarrierData().metadata.footnotes, function (footnote) {
                     return footnote.id === footnoteId;
-                 });
+                });
             }
 
             return match;


### PR DESCRIPTION
This PR replaces `Array.find` with `_.find`. `Array.find` is [not supported by old browsers like IE](https://caniuse.com/#feat=array-find). You already use `_.find` at various other places, so replacing these two problematic occurrences of `Array.find` with `_.find` is the right way to fix this IMHO.

Even though this is a tiny change, please mind that it is currently **untested**.